### PR TITLE
Updating eks auth configmap 

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -28,3 +28,8 @@ data "aws_ami" "ubuntu" {
 
   owners = ["099720109477"] # Canonical
 }
+
+data "aws_iam_roles" "admin_role" {
+  name_regex  = "AWSReservedSSO_AWSAdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}

--- a/eks_cluster.tf
+++ b/eks_cluster.tf
@@ -42,4 +42,18 @@ module "eks" {
       ]
     }
   }
+
+  # Allow setting access permissions to the eks cluster (e.g., who can run kubectl commands) via aws-auth configmap
+  manage_aws_auth_configmap = true
+
+  # Allow all users in an AWS environment with the "AWSAdministratorAccess" role to run kubectl commands
+  aws_auth_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${tolist(data.aws_iam_roles.admin_role.names)[0]}"
+      username = "AWSAdministratorAccess:{{SessionName}}"
+      groups = [
+        "system:masters",
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This PR:

- Updates the EKS aws-auth configmap definition to allow kubectl access to users with the AWSAdministratorAccess IAM role