### PR TITLE
RDS hardware updates + other changes

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,23 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.36.1"
-  constraints = ">= 3.72.0, >= 3.73.0, 4.36.1"
+  version     = "4.47.0"
+  constraints = ">= 3.72.0, >= 3.73.0, 4.47.0"
   hashes = [
-    "h1:bVdhic55ukDoSukFwOOqX2q/gZ5efe4aBTMGivEuY4o=",
-    "h1:sN3HFvBwuCn+ipD9Ti5OnBJ+V9CzUXviJ2py6tiCK6Q=",
-    "zh:19b16047b4f15e9b8538a2b925f1e860463984eed7d9bd78e870f3e884e827a7",
-    "zh:3c0db06a9a14b05a77f3fe1fc029a5fb153f4966964790ca8e71ecc3427d83f5",
-    "zh:3c7407a8229005e07bc274cbae6e3a464c441a88810bfc6eceb2414678fd08ae",
-    "zh:3d96fa82c037fafbd3e7f4edc1de32afb029416650f6e392c39182fc74a9e03a",
-    "zh:8f4f540c5f63d847c4b802ca84d148bb6275a3b0723deb09bf933a4800bc7209",
-    "zh:9802cb77472d6bcf24c196ce2ca6d02fac9db91558536325fec85f955b71a8a4",
+    "h1:BdJV7bQPBSHvy23vKDr0il05BArQUIco/XbJjHjNNsI=",
+    "zh:01afccb7e358ccff4ad800bcdea785198669f23070fba4561c65eb05f4364fc4",
+    "zh:0c45f46461d666c6e084ed742dbf01c9d9dc749e691771717c5ac1f82f4f6e74",
+    "zh:291ddb5a4c0da5fdd2f247ee37089a0f5e48e8446bdad2ed0f9b39cb71a11a9d",
+    "zh:338a888c04ff0da3642b64dbc29f45e5d734dd88d7c4c101c2d9a0bde726d40b",
+    "zh:35cd3c76f485f4486f187032807ef4aad99fac51e32b0ac341ab4e6fe30f2bf1",
+    "zh:39296c9baf7863fdd64194d932ec81886a4d207c05d34474be43abfeeb0f13e2",
+    "zh:6dc77793b52f127f2f48a5353865d8879eab44e5db4b837625eaa35fc842114c",
+    "zh:8bb8c7488e69a65f08bfadbf0b0801bafa28bde9ae908d12dc7490a81b88d368",
+    "zh:8fcfb26008559f514f80a8ab6d380211dfaaa902cb9e9ff2af3203bbe4c9f506",
+    "zh:95a69ccc0fdd5756d3c7311788908ab5fd1392e271b8478f3ee11238c3cbcc57",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a263352433878c89832c2e38f4fd56cf96ae9969c13b5c710d5ba043cbd95743",
-    "zh:aca7954a5f458ceb14bf0c04c961c4e1e9706bf3b854a1e90a97d0b20f0fe6d3",
-    "zh:d78f400332e87a97cce2e080db9d01beb01f38f5402514a6705d6b8167e7730d",
-    "zh:e14bdc49be1d8b7d2543d5c58078c84b76051085e8e6715a895dcfe6034b6098",
-    "zh:f2e400b88c8de170bb5027922226da1e9a6614c03f2a6756c15c3b930c2f460c",
+    "zh:a93a1320344d9e8f10a8e6b81b9fabfa36fb824a9b7bcb252fa060523dd0da62",
+    "zh:c4902c4aebb4174442fef42ea4a093c5881973a27a5d2c171d7d18a6e092f756",
+    "zh:c70a757e63ffc62d74003ab7719443012c57a2bbb0ae275c5c25a30aaa21dbf2",
+    "zh:de0ef6684a81f74766629bfdc3206cde58a2e1619c9d1b65d199148da3b2f50e",
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "4.36.1"
+      version = "4.47.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/rds.tf
+++ b/rds.tf
@@ -18,9 +18,8 @@ resource "aws_db_instance" "oracle_rds" {
 
   # Hardware, Storage & Backup
   storage_type            = "gp3"
-  allocated_storage       = 100
+  allocated_storage       = 400 # 400GB here to get to the next threshold for IOPS (12000) and throughput (500MiB)
   max_allocated_storage   = 1000
-  storage_throughput      = 500
   storage_encrypted       = true
   skip_final_snapshot     = true
   backup_retention_period = 30

--- a/rds.tf
+++ b/rds.tf
@@ -1,26 +1,30 @@
 resource "aws_db_instance" "oracle_rds" {
-  db_name                             = "oracle"
-  identifier                          = "oracle-rds"
-  engine                              = "postgres"
-  engine_version                      = "14.5" # Latest available
-  username                            = "oracle_admin"
-  port                                = 5432
-  skip_final_snapshot                 = true
-  parameter_group_name                = aws_db_parameter_group.oracle_rds_parameter_group.name
-  db_subnet_group_name                = module.vpc.database_subnet_group
-  storage_encrypted                   = true
-  vpc_security_group_ids              = [aws_security_group.rds_security_group.id]
-  backup_retention_period             = 30
-  iam_database_authentication_enabled = true
-  multi_az                            = true
+  # RDS info
+  db_name                         = "oracle"
+  identifier                      = "oracle-rds"
+  engine                          = "postgres"
+  engine_version                  = "14.5" # Latest available
+  username                        = "oracle_admin"
+  password                        = random_password.oracle_pg_admin_password.result
+  parameter_group_name            = aws_db_parameter_group.oracle_rds_parameter_group.name
+  multi_az                        = true
+  enabled_cloudwatch_logs_exports = ["postgresql"]
 
-  # TODO - Need to finalize below
-  allocated_storage    = 400 # Need to specificy max_allocated_storage to enable autoscaling
-  instance_class       = "db.t3.micro" 
-  password             =  random_password.oracle_pg_admin_password.result # Create a pw in parameter store and reference here
-  iops                 = 3000
-  storage_type         = "io1"
-  # All things monitoring ..
+  # Networking & Security
+  port                                = 5432
+  db_subnet_group_name                = module.vpc.database_subnet_group
+  vpc_security_group_ids              = [aws_security_group.rds_security_group.id]
+  iam_database_authentication_enabled = true
+
+  # Hardware, Storage & Backup
+  storage_type            = "gp3"
+  allocated_storage       = 100
+  max_allocated_storage   = 1000
+  storage_throughput      = 500
+  storage_encrypted       = true
+  skip_final_snapshot     = true
+  backup_retention_period = 30
+  instance_class          = "db.m6i.large"
 }
 
 # RDS parameter group to force SSL

--- a/rds_secrets_manager.tf
+++ b/rds_secrets_manager.tf
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret_rotation" "rotation" {
   rotation_lambda_arn = aws_serverlessapplicationrepository_cloudformation_stack.rotator_cf_stack.outputs.RotationLambdaARN
 
   rotation_rules {
-    automatically_after_days = 1 # Can change as needed, this is just for testing
+    automatically_after_days = 30
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,10 +55,6 @@ variable "cluster_desired_size" {
   default = 2
 }
 
-variable "rds_password" {
-  type = string
-}
-
 # Bastion variables
 variable "ec2_bastion_private_ip" {
   type = string


### PR DESCRIPTION
This PR:

- Updates the RDS hardware specifications
- Updates the RDS password rotation to 30 days
- Updates the `hashicorp/aws` version to `4.47.0` in order to be able to use `gp3` EBS volume type
- Removes unneeded vars

