### PR TITLE
Oracle/bastion ssh access alerts

### DIFF
--- a/oracle/ec2_bastion.tf
+++ b/oracle/ec2_bastion.tf
@@ -15,7 +15,7 @@ resource "aws_instance" "bastion" {
     aws_security_group.rds_access_security_group.id, 
     aws_security_group.ec2_bastion_security_group.id
   ]
-  iam_instance_profile = aws_iam_role.bastion_cw_agent_role.name
+  iam_instance_profile = aws_iam_instance_profile.bastion_instance_profile.name
 
   # Storage 
   root_block_device {

--- a/oracle/ec2_bastion_cloudwatch.tf
+++ b/oracle/ec2_bastion_cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_log_group" "bastion_ssh_denied_log_group" {
 # Add CloudWatch metrics filter to ssh access logs pulled shipped from Bastion to isolate failed login attempts as a metric 
 resource "aws_cloudwatch_log_metric_filter" "bastion_ssh_metrics_filter" {
   name           = "bastion-ssh-metrics-filter"
-  pattern        = "failed, status 22"
+  pattern        = "\"failed,\" status 22"
   log_group_name = aws_cloudwatch_log_group.bastion_ssh_denied_log_group.name
 
   metric_transformation {

--- a/oracle/ec2_bastion_cloudwatch.tf
+++ b/oracle/ec2_bastion_cloudwatch.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_log_group" "bastion_ssh_denied_log_group" {
 # Add CloudWatch metrics filter to ssh access logs pulled shipped from Bastion to isolate failed login attempts as a metric 
 resource "aws_cloudwatch_log_metric_filter" "bastion_ssh_metrics_filter" {
   name           = "bastion-ssh-metrics-filter"
-  pattern        = "\"failed,\" status 22"
+  pattern        = "status 22"
   log_group_name = aws_cloudwatch_log_group.bastion_ssh_denied_log_group.name
 
   metric_transformation {

--- a/oracle/ec2_bastion_iam.tf
+++ b/oracle/ec2_bastion_iam.tf
@@ -2,7 +2,7 @@
 # Needed for ssh access slack alerting 
 resource "aws_iam_role" "bastion_cw_agent_role" {
   name        = "bastion-cloudwatch-agent-role"
-  description = "EC2 IAM Instance Profile to facilitate logging by CloudWatch Agent"
+  description = "IAM role for EC2 Instance Profile to facilitate logging by CloudWatch Agent"
 
   managed_policy_arns = ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]
 
@@ -19,4 +19,11 @@ resource "aws_iam_role" "bastion_cw_agent_role" {
       },
     ]
   })
+}
+
+
+# EC2 Instance Profile to facilitate logging by CloudWatch Agent on bastion
+resource "aws_iam_instance_profile" "bastion_instance_profile" {
+  name = "bastion_instance_profile_for_cw_agent"
+  role = aws_iam_role.bastion_cw_agent_role.name
 }


### PR DESCRIPTION
This PR:
- Creates instance profile from bastion cloudwatch agent role
- Updates filtering of bastion ssh logs
- Updates bastion to use instance profile