### PR TITLE
Update aws lbc

### DIFF
--- a/modules/k8s/lb.tf
+++ b/modules/k8s/lb.tf
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy" "lb" {
 resource "helm_release" "lbc" {
   name             = "aws-load-balancer-controller"
   chart            = "aws-load-balancer-controller"
-  version          = "1.4.5"
+  version          = "1.5.4"
   namespace        = "default"
   repository       = "https://aws.github.io/eks-charts"
   create_namespace = true


### PR DESCRIPTION
Update to aws-load-balancer-controller `1.5.4` in advance of updating k8s/eks to `1.25`

- https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.25